### PR TITLE
Fix Offset between Collision and Tile Rendering

### DIFF
--- a/src/systems/TileMapRenderSystem.lua
+++ b/src/systems/TileMapRenderSystem.lua
@@ -25,7 +25,7 @@ function TileMapRenderSystem:update(dt)
         tm:resize(lgw, lgh)
     end
     tm:update(dt)
-    tm:draw(-tx, -ty + 16, s)
+    tm:draw(-tx + 16, -ty + 16, s)
 end
 
 return TileMapRenderSystem


### PR DESCRIPTION
The collision were a tile to the right of where they should be.